### PR TITLE
Handle blocked YouTube tracks gracefully

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -892,6 +892,18 @@ p {
   color: #d63384;
 }
 
+.player-track.is-unavailable button {
+  background: rgba(255, 255, 255, 0.28);
+  color: rgba(122, 90, 107, 0.6);
+  cursor: not-allowed;
+}
+
+.player-track.is-unavailable button:hover {
+  background: rgba(255, 255, 255, 0.28);
+  transform: none;
+  color: rgba(122, 90, 107, 0.6);
+}
+
 .player.is-playing .player-disc {
   animation-play-state: running;
 }


### PR DESCRIPTION
## Summary
- detect background-music tracks that fail to load and mark them as unavailable in the playlist
- automatically skip blocked songs and continue playback, while updating the player status text
- style disabled tracks so it is clear they cannot be selected

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db7510c400832a98411dfdba202a6a