### PR TITLE
Fix autoplay by waiting for YouTube player readiness

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -592,7 +592,7 @@ function ensureYouTubePlayer() {
   if (!yt) {
     return Promise.resolve(null);
   }
-  if (ytPlayer && typeof ytPlayer.loadVideoById === 'function') {
+  if (ytPlayer && youTubePlayerReadyResolved && typeof ytPlayer.loadVideoById === 'function') {
     return Promise.resolve(ytPlayer);
   }
   ensureYouTubeIframeAPIScript();


### PR DESCRIPTION
## Summary
- ensure the YouTube player promise only resolves after the iframe API has fully initialized
- prevent loadVideo calls from running before the player is ready, so tracks start correctly after unlocking

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb5dcc708832aa27c842401250f18