### PR TITLE
Adjust header and hero emoji animations

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -87,10 +87,25 @@ nav {
   justify-content: space-between;
 }
 .brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   font-family: 'Sacramento', cursive;
   font-size: 2rem;
   color: #d63384;
   letter-spacing: 0.5px;
+}
+
+.brand-title {
+  display: inline-block;
+}
+
+.brand-heart {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  animation: brandHeartFlip 2s linear infinite;
+  transform-origin: center;
 }
 
 .brand .typewriter {
@@ -754,11 +769,11 @@ p {
   align-items: center;
   justify-content: center;
   font-size: 1em;
-  animation: heroFlowerFlip 1.8s linear infinite;
+  animation: heroFlowerBloom 2.6s ease-in-out infinite;
   transform-origin: center;
 }
 
-@keyframes heroFlowerFlip {
+@keyframes brandHeartFlip {
   0% {
     transform: rotateY(0deg);
   }
@@ -767,6 +782,25 @@ p {
   }
   100% {
     transform: rotateY(360deg);
+  }
+}
+
+@keyframes heroFlowerBloom {
+  0% {
+    opacity: 0;
+    transform: scale(0.9) translateY(6px);
+  }
+  35% {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+  65% {
+    opacity: 1;
+    transform: scale(1.02) translateY(-2px);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(0.95) translateY(6px);
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -31,13 +31,8 @@
     <nav>
       <div class="container nav-inner">
         <div class="brand" aria-label="Lynx's Love Story ❤️">
-          <span
-            class="typewriter"
-            data-typewriter="Lynx's Love Story ❤️"
-            data-typewriter-speed="85"
-          >
-            Lynx's Love Story ❤️
-          </span>
+          <span class="brand-title">Lynx's Love Story</span>
+          <span class="brand-heart" role="img" aria-hidden="true">❤️</span>
         </div>
         <div class="menu">
           <a href="#home">Home</a>


### PR DESCRIPTION
## Summary
- replace the navigation brand typewriter with a static title and continuously flipping heart icon
- update the hero flower emoji animation to use a looping fade-and-reveal effect

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbfea96388832aae8c0a40af486f32