### PR TITLE
Update hero greeting and adjust carousel image framing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -249,6 +249,9 @@ p {
   height: 100%;
   position: relative;
   display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(200deg, rgba(255, 255, 255, 0.8), rgba(255, 216, 233, 0.85));
 }
 
 .hero-carousel__slide::after {
@@ -267,7 +270,9 @@ p {
   cursor: zoom-in;
   width: 100%;
   height: 100%;
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .hero-carousel__lightbox-trigger:focus-visible {
@@ -278,10 +283,11 @@ p {
 .hero-carousel__image {
   width: 100%;
   height: 100%;
-  object-fit: cover;
-  object-position: center top;
+  object-fit: contain;
+  object-position: center;
   display: block;
   filter: saturate(1.05) contrast(1.02);
+  background: #fff;
 }
 
 .hero-carousel__nav {
@@ -871,8 +877,11 @@ p {
 }
 
 .love-lightbox--photo .love-lightbox__image {
-  max-height: min(80vh, 640px);
-  object-fit: cover;
+  width: 100%;
+  height: auto;
+  max-height: min(85vh, 700px);
+  object-fit: contain;
+  background: #fff;
 }
 
 .love-lightbox__caption {

--- a/index.html
+++ b/index.html
@@ -52,11 +52,11 @@
             <h1>
               <span
                 class="typewriter hero-typewriter"
-                data-typewriter="Hi, my Empress"
+                data-typewriter="Hi, Wifey"
                 data-typewriter-speed="110"
                 data-typewriter-delay="120"
               >
-                Hi, my Empress
+                Hi, Wifey
               </span>
               <span class="hero-flower" role="img" aria-label="Rose">🌹</span>
             </h1>


### PR DESCRIPTION
## Summary
- update the hero greeting copy to say "Hi, Wifey"
- restyle the hero carousel track so images scale within view without being cropped between slides
- size the photo lightboxes with contain fit so the top of each image stays visible

## Testing
- Manually opened http://127.0.0.1:8000/index.html

------
https://chatgpt.com/codex/tasks/task_e_68e54395f1c0832aaed05b88f1940d46