### PR TITLE
Improve hero gallery lightbox and playlist controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -251,7 +251,10 @@ p {
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: clamp(16px, 3vw, 32px);
+  border-radius: clamp(18px, 3vw, 28px);
   background: linear-gradient(200deg, rgba(255, 255, 255, 0.8), rgba(255, 216, 233, 0.85));
+  overflow: hidden;
 }
 
 .hero-carousel__slide::after {
@@ -261,6 +264,7 @@ p {
   background: linear-gradient(180deg, rgba(0, 0, 0, 0) 35%, rgba(0, 0, 0, 0.22) 100%);
   mix-blend-mode: multiply;
   pointer-events: none;
+  border-radius: inherit;
 }
 
 .hero-carousel__lightbox-trigger {
@@ -281,13 +285,17 @@ p {
 }
 
 .hero-carousel__image {
-  width: 100%;
-  height: 100%;
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: 100%;
   object-fit: contain;
   object-position: center;
   display: block;
   filter: saturate(1.05) contrast(1.02);
   background: #fff;
+  border-radius: clamp(14px, 2.6vw, 24px);
+  box-shadow: 0 12px 28px rgba(199, 42, 115, 0.18);
 }
 
 .hero-carousel__nav {
@@ -876,6 +884,16 @@ p {
   padding: clamp(18px, 3vw, 28px);
 }
 
+.love-lightbox--photo .love-lightbox__viewer {
+  gap: clamp(12px, 2.5vw, 20px);
+}
+
+.love-lightbox--photo .love-lightbox__stage {
+  cursor: default;
+  touch-action: auto;
+  max-height: min(80vh, 720px);
+}
+
 .love-lightbox--photo .love-lightbox__image {
   width: 100%;
   height: auto;
@@ -1124,6 +1142,14 @@ p {
   background: linear-gradient(165deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.58));
   box-shadow: 0 18px 48px rgba(214, 31, 114, 0.28);
   backdrop-filter: blur(16px);
+  opacity: 0.68;
+  transition: opacity 0.25s ease, box-shadow 0.25s ease;
+}
+
+.player:hover,
+.player:focus-within {
+  opacity: 1;
+  box-shadow: 0 20px 52px rgba(214, 31, 114, 0.32);
 }
 
 .player-body {
@@ -1240,6 +1266,78 @@ p {
   color: #b07a94;
   font-weight: 700;
   padding-left: 4px;
+}
+
+.player-playlist-accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.player-list-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  border: none;
+  border-radius: 18px;
+  padding: 10px 16px;
+  background: rgba(255, 255, 255, 0.52);
+  cursor: url('../images/heart_cursor.svg') 8 8, pointer;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 8px 18px rgba(214, 31, 114, 0.12);
+}
+
+.player-list-toggle:hover {
+  background: rgba(255, 255, 255, 0.78);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 26px rgba(214, 31, 114, 0.18);
+}
+
+.player-list-toggle:focus-visible {
+  outline: 3px solid rgba(255, 143, 194, 0.85);
+  outline-offset: 2px;
+}
+
+.player-list-toggle__icon {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, rgba(255, 120, 180, 0.95), rgba(255, 170, 210, 0.95));
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-size: 0.95rem;
+  line-height: 1;
+  transition: transform 0.25s ease;
+}
+
+.player-list-toggle__icon::before {
+  content: '⌄';
+  transform: translateY(-1px);
+}
+
+.player-playlist-panel {
+  overflow: hidden;
+  transition: max-height 0.3s ease, opacity 0.3s ease, margin-top 0.3s ease;
+  max-height: 220px;
+  opacity: 1;
+}
+
+.player--playlist-collapsed .player-playlist-panel {
+  max-height: 0;
+  opacity: 0;
+  margin-top: -6px;
+  pointer-events: none;
+}
+
+.player--playlist-collapsed .player-list-toggle__icon {
+  transform: rotate(-180deg);
+}
+
+.player--playlist-collapsed .player-playlist {
+  overflow: hidden;
 }
 
 .player-playlist {

--- a/index.html
+++ b/index.html
@@ -251,7 +251,23 @@
       <div class="love-lightbox love-lightbox--photo" id="heroLightbox" aria-hidden="true" tabindex="-1">
         <div class="love-lightbox__content" role="dialog" aria-modal="true" aria-label="Full size memory photo">
           <button type="button" class="love-lightbox__close" id="heroLightboxClose" aria-label="Close photo"></button>
-          <img id="heroLightboxImage" alt="" class="love-lightbox__image" />
+          <div class="love-lightbox__viewer">
+            <button
+              type="button"
+              class="love-lightbox__nav love-lightbox__nav--prev"
+              id="heroLightboxPrev"
+              aria-label="View previous memory"
+            ></button>
+            <div class="love-lightbox__stage" id="heroLightboxStage">
+              <img id="heroLightboxImage" alt="" class="love-lightbox__image" />
+            </div>
+            <button
+              type="button"
+              class="love-lightbox__nav love-lightbox__nav--next"
+              id="heroLightboxNext"
+              aria-label="View next memory"
+            ></button>
+          </div>
         </div>
       </div>
 
@@ -298,8 +314,21 @@
           </div>
         </div>
       </div>
-      <div class="player-list-header">Playlist</div>
-      <ul class="player-playlist" id="playlist"></ul>
+      <div class="player-playlist-accordion">
+        <button
+          class="player-list-toggle"
+          id="playlistToggle"
+          type="button"
+          aria-expanded="true"
+          aria-controls="playlistPanel"
+        >
+          <span class="player-list-header">Playlist</span>
+          <span class="player-list-toggle__icon" aria-hidden="true"></span>
+        </button>
+        <div class="player-playlist-panel" id="playlistPanel">
+          <ul class="player-playlist" id="playlist"></ul>
+        </div>
+      </div>
     </div>
 
     <button type="button" class="scroll-top" id="scrollTopBtn" aria-label="Scroll back to top">


### PR DESCRIPTION
## Summary
- add explicit navigation controls to the hero lightbox with keyboard support and shared carousel state
- adjust hero carousel slide styling so images stay contained without cropping during transitions
- convert the floating music playlist into an accessible accordion with reduced idle opacity and inert collapsed content

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e795d1bf10832ab84e9ff925a109f9